### PR TITLE
Add type checking for apps/sample-api

### DIFF
--- a/apps/sample-api/__tests__/unit/category.controller.test.ts
+++ b/apps/sample-api/__tests__/unit/category.controller.test.ts
@@ -37,7 +37,7 @@ describe.only('categoryController.find', () => {
   });
 
   it.only('should return status 200 and authors', async () => {
-    await CategoryController.find(req, res);
+    await CategoryController.find(req, res, () => {});
     assert.strictEqual(res.statusCode, 200);
   });
 });

--- a/apps/sample-api/global.d.ts
+++ b/apps/sample-api/global.d.ts
@@ -1,7 +1,33 @@
 declare var logger: {
-  error(msg: string, meta?: Record<string, unknown>): void;
-  warn(msg: string, meta?: Record<string, unknown>): void;
-  info(msg: string, meta?: Record<string, unknown>): void;
-  debug(msg: string, meta?: Record<string, unknown>): void;
+  error(msg: unknown, meta?: unknown): void;
+  warn(msg: unknown, meta?: unknown): void;
+  info(msg: unknown, meta?: unknown): void;
+  debug(msg: unknown, meta?: unknown): void;
 };
-declare var __config: Readonly<Record<string, unknown>>;
+// biome-ignore lint/suspicious/noExplicitAny: global config shape is dynamic at runtime
+declare var __config: Readonly<Record<string, any>>;
+
+declare namespace Express {
+  interface Request {
+    user?: {
+      sub?: string | number;
+      roles?: string[];
+      tenant_id?: number;
+      tenant_plan?: string | null;
+      [key: string]: unknown;
+    };
+    fga?: {
+      check(relation: string, object: string): Promise<boolean>;
+    };
+    rbac?: {
+      hasRole(...roles: string[]): boolean;
+    };
+    log: {
+      error(msg: unknown, meta?: Record<string, unknown>): void;
+      warn(msg: unknown, meta?: Record<string, unknown>): void;
+      info(msg: unknown, meta?: Record<string, unknown>): void;
+      debug(msg: unknown, meta?: Record<string, unknown>): void;
+    };
+    startTime: number;
+  }
+}

--- a/apps/sample-api/package.json
+++ b/apps/sample-api/package.json
@@ -30,7 +30,7 @@
     "lint": "biome check .",
     "start": "node --watch --watch-preserve-output --trace-warnings src/index.ts",
     "test:unit": "node --test-reporter=spec --experimental-test-coverage --experimental-test-module-mocks --test --test-only ./__tests__/unit/*.test.ts",
-    "test:integration": "node --test-reporter=spec --experimental-test-coverage --test --test-only ./__tests__/integration/*.test.ts",
+    "test:integration": "node --test-reporter=spec --test --test-only --test-isolation=process --test-concurrency=1 ./__tests__/integration/*.test.ts",
     "test:integration:oidc": "node --test-reporter=spec --test --test-only ./__tests__/integration/oidc.routes.test.ts",
     "test:integration:saml": "node --test-reporter=spec --test --test-only ./__tests__/integration/saml.routes.test.ts",
     "test:schema": "node ../../scripts/test-schemas.ts ./schemas",

--- a/apps/sample-api/package.json
+++ b/apps/sample-api/package.json
@@ -35,7 +35,8 @@
     "test:integration:saml": "node --test-reporter=spec --test --test-only ./__tests__/integration/saml.routes.test.ts",
     "test:schema": "node ../../scripts/test-schemas.ts ./schemas",
     "test": "npm run test:unit && npm run test:integration && npm run test:schema",
-    "test:e2e": "start-server-and-test start http://localhost:8080 test"
+    "test:e2e": "start-server-and-test start http://localhost:8080 test",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@common/iso": "file:../../common/vanilla/iso",

--- a/apps/sample-api/public/demo-express/redoc.html
+++ b/apps/sample-api/public/demo-express/redoc.html
@@ -19,6 +19,6 @@
   </head>
   <body>
     <redoc spec-url='http://petstore.swagger.io/v2/swagger.json'></redoc>
-    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js">                                                                </script>
+    <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js">                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                </script>
   </body>
 </html>

--- a/apps/sample-api/src/index.ts
+++ b/apps/sample-api/src/index.ts
@@ -5,7 +5,7 @@ import { server } from './app.ts';
 
 (async () => {
   // if development && hostname == localhost allow TLS - call after config load
-  if (process.env.NODE_ENV === 'development') process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+  if (process.env.NODE_ENV === 'development') process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
   const { API_PORT, HTTPS_CERTIFICATE, NODE_ENV } = process.env;
   server.listen(API_PORT, () => logger.info(`Env=${NODE_ENV}, Port=${API_PORT}, https=${Boolean(HTTPS_CERTIFICATE)}`));
 })();

--- a/apps/sample-api/src/routes/base.ts
+++ b/apps/sample-api/src/routes/base.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import * as s from '@common/node/services';
 import express from 'express';
 
@@ -17,7 +18,7 @@ export default express
   .get('/', (req, res) => res.send({ status: 'sample-api OK' }))
   .get('/healthcheck', (req, res) => res.send({ status: 'sample-api/healthcheck OK' }))
   .get('/check-db', async (req, res) => {
-    const connectionName = req.query.conn || 'knex1'; // refer to .env.sample file for this value
+    const connectionName = (req.query.conn as string) || 'knex1'; // refer to .env.sample file for this value
     const knexDB = s.get(connectionName); // knex object, can have more than 1
     const { config } = knexDB.context.client;
     const rv = await knexDB.raw('SELECT 1'); // also can try knexDB(<table name>).query()

--- a/apps/sample-api/src/routes/fido.ts
+++ b/apps/sample-api/src/routes/fido.ts
@@ -55,7 +55,12 @@ const f2l = new Fido2Lib({
   authenticatorUserVerification: 'required',
 });
 
-let testInfo: Record<string, any> = {};
+interface FidoTestInfo {
+  credId?: ArrayBuffer;
+  counter?: number;
+  publicKey?: string;
+}
+let testInfo: FidoTestInfo = {};
 
 // TODO make below scalable
 const registerChallenge = '33EHav-jZ1v9qwH783aU-j0ARx6r5o-YHh-wd7C6jPbd7Wh6ytbIZosIIACehwf9-s6hXhySHO-HHUjEwZS29w'; //  base64url
@@ -155,11 +160,12 @@ export default express
       userHandle: 'test',
     };
 
-    const credentialId = b_b64(ab_b(testInfo.credId));
+    const credentialId = b_b64(ab_b(testInfo.credId as ArrayBuffer));
     assertionExpectations.allowCredentials = [];
     assertionExpectations.allowCredentials.push({ type: 'public-key', id: credentialId });
 
     // const authnResult =
+    // biome-ignore lint/suspicious/noExplicitAny: fido2-lib AssertionExpectations type does not match runtime shape
     await f2l.assertionResult(regResponse, assertionExpectations as any); // will throw on error
     // logger.info(authnResult)
     res.json({ msg: 'validate ok' });

--- a/apps/sample-api/src/routes/fido.ts
+++ b/apps/sample-api/src/routes/fido.ts
@@ -55,16 +55,17 @@ const f2l = new Fido2Lib({
   authenticatorUserVerification: 'required',
 });
 
-let testInfo = {};
+let testInfo: Record<string, any> = {};
 
 // TODO make below scalable
 const registerChallenge = '33EHav-jZ1v9qwH783aU-j0ARx6r5o-YHh-wd7C6jPbd7Wh6ytbIZosIIACehwf9-s6hXhySHO-HHUjEwZS29w'; //  base64url
-let validateChallenge = ''; // ab
+let validateChallenge: unknown = ''; // ab
 
 export default express
   .Router()
   .get('/register', async (req, res) => {
-    const registrationOptions = await f2l.attestationOptions();
+    // biome-ignore lint/suspicious/noExplicitAny: fido2-lib types don't match runtime shape
+    const registrationOptions = (await f2l.attestationOptions()) as any;
     const userId = 'bXl1c2Vy'; // base64url // 'aaronjxz' // (convert to Uint8Array on client side)
 
     registrationOptions.challenge = registerChallenge;
@@ -87,7 +88,8 @@ export default express
       factor: 'either',
     };
 
-    const regResult = await f2l.attestationResult(regResponse, attestationExpectations);
+    // biome-ignore lint/suspicious/noExplicitAny: fido2-lib Factor type requires cast
+    const regResult = await f2l.attestationResult(regResponse, attestationExpectations as any);
 
     // registration complete!
     // save publicKey and counter from regResult to user's info for future authentication calls
@@ -101,12 +103,13 @@ export default express
       counter,
       publicKey,
     };
-    logger.info(credId, counter, publicKey);
+    logger.info('registration data', { credId, counter, publicKey });
 
     res.json({ msg: 'register ok' });
   })
   .get('/validate', async (req, res) => {
-    const authnOptions = await f2l.assertionOptions();
+    // biome-ignore lint/suspicious/noExplicitAny: fido2-lib types don't match runtime shape
+    const authnOptions = (await f2l.assertionOptions()) as any;
     logger.info(authnOptions);
 
     validateChallenge = authnOptions.challenge; // store challenge
@@ -136,14 +139,15 @@ export default express
     const regResponse = req.body;
     regResponse.rawId = b_ab(b64url_b(regResponse.rawId));
 
-    const assertionExpectations = {
+    // biome-ignore lint/suspicious/noExplicitAny: fido2-lib types don't match runtime shape
+    const assertionExpectations: Record<string, any> = {
       // Remove the following comment if allowCredentials has been added into authnOptions so the credential received will be validate against allowCredentials array.
       // allowCredentials: [{
       //     id: "lTqW8H/lHJ4yT0nLOvsvKgcyJCeO8LdUjG5vkXpgO2b0XfyjLMejRvW5oslZtA4B/GgkO/qhTgoBWSlDqCng4Q==",
       //     type: "public-key",
       //     transports: ["usb"]
       // }],
-      challenge: b_b64url(ab_b(validateChallenge)), // "eaTyUNnyPDDdK8SNEgTEUvz1Q8dylkjjTimYd5X7QAo-F8_Z1lsJi3BilUpFZHkICNDWY8r9ivnTgW7-XZC3qQ", // validateChallenge
+      challenge: b_b64url(ab_b(validateChallenge as ArrayBuffer)), // "eaTyUNnyPDDdK8SNEgTEUvz1Q8dylkjjTimYd5X7QAo-F8_Z1lsJi3BilUpFZHkICNDWY8r9ivnTgW7-XZC3qQ", // validateChallenge
       origin,
       factor: 'either',
       publicKey: testInfo.publicKey,
@@ -156,7 +160,7 @@ export default express
     assertionExpectations.allowCredentials.push({ type: 'public-key', id: credentialId });
 
     // const authnResult =
-    await f2l.assertionResult(regResponse, assertionExpectations); // will throw on error
+    await f2l.assertionResult(regResponse, assertionExpectations as any); // will throw on error
     // logger.info(authnResult)
     res.json({ msg: 'validate ok' });
   });

--- a/apps/sample-api/src/routes/sse.ts
+++ b/apps/sample-api/src/routes/sse.ts
@@ -1,9 +1,9 @@
 import express from 'express';
 
-let clients = [];
+let clients: { id: number; res: any }[] = [];
 
-function sendEventsToAll(data) {
-  logger.info('Send SSE', clients, data);
+function sendEventsToAll(data: unknown) {
+  logger.info('Send SSE', { data });
   clients.forEach(client => {
     client.res.write(`data: ${JSON.stringify(data)}`);
   });

--- a/apps/sample-api/src/routes/sse.ts
+++ b/apps/sample-api/src/routes/sse.ts
@@ -1,6 +1,7 @@
+import type { Response } from 'express';
 import express from 'express';
 
-let clients: { id: number; res: any }[] = [];
+let clients: { id: number; res: Response }[] = [];
 
 function sendEventsToAll(data: unknown) {
   logger.info('Send SSE', { data });

--- a/apps/sample-api/src/routes/tests.ts
+++ b/apps/sample-api/src/routes/tests.ts
@@ -41,7 +41,7 @@ export default express
   })
   .get('/error', (req, res) => {
     // error caught by error middleware
-    (req as any).something.missing = 10;
+    (req as unknown as { something: { missing: number } }).something.missing = 10;
     res.json({ message: 'OK' });
   })
   .get('/error-handled-rejection', async (req, res) => {

--- a/apps/sample-api/src/routes/tests.ts
+++ b/apps/sample-api/src/routes/tests.ts
@@ -34,14 +34,14 @@ export default express
   }) // check if send header as application/json but body is text
   .get('/outbound', async (req, res) => {
     // test outbound unblocked
-    const url = req.query.url || 'https://httpbin.org/get';
+    const url = (req.query.url as string) || 'https://httpbin.org/get';
     const rv = await fetch(url);
     const data = await rv.json();
     res.json(data);
   })
   .get('/error', (req, res) => {
     // error caught by error middleware
-    req.something.missing = 10;
+    (req as any).something.missing = 10;
     res.json({ message: 'OK' });
   })
   .get('/error-handled-rejection', async (req, res) => {
@@ -71,20 +71,20 @@ export default express
   })
   .get('/download', (req, res, next) => {
     // serve a file download, you can add authorization here to control downloads
-    const { filename } = req.query;
+    const { filename } = req.query as { filename: string };
     const fullPath = path.join(UPLOAD_STATIC[0].folder, filename);
 
     // Stream file instead
     const file = fs.createReadStream(fullPath);
     res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader(['Content-Disposition', `inline; filename="${filename}"`]);
+    res.setHeader('Content-Disposition', `inline; filename="${filename}"`);
     file.pipe(res);
   })
 
   // message queues
   .get('/mq-agenda', async (req, res) => {
     // test message queue - agenda
-    res.json({ job, note: 'TODO' });
+    res.json({ job: null, note: 'TODO' });
   })
 
   // test websocket broadcast
@@ -98,7 +98,7 @@ export default express
   // body action: 'read' | 'write', filename: 'my-file.txt', bucket: 'bucket name'
   .post('/upload-disk', storageUpload(UPLOAD_STATIC[0]).any(), (req, res) => {
     // avatar is form input name // single('filedata')
-    logger.info('files', req, req.files);
+    logger.info('upload', { files: req.files });
     // body is string, need to parse if json
     res.json({
       ok: true, // success

--- a/apps/sample-api/tsconfig.json
+++ b/apps/sample-api/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "strict": false,
+    "noImplicitAny": false,
+    "skipLibCheck": true,
+    "erasableSyntaxOnly": true
+  },
+  "include": ["src/**/*.ts", "global.d.ts", "__tests__/**/*.ts"]
+}

--- a/common/compiled/node/auth/controllers/own.ts
+++ b/common/compiled/node/auth/controllers/own.ts
@@ -28,7 +28,7 @@ const logout = async (req: Request, res: Response): Promise<void> => {
     const access_token = (tmp as string).split(' ')[1];
     const user = jwt.decode(access_token) as Record<string, unknown>;
     id = user?.sub as string;
-    jwt.verify(access_token, getSecret('verify'), { algorithm: [JWT_ALG] });
+    jwt.verify(access_token, getSecret('verify'), { algorithms: [JWT_ALG] });
   } catch (e) {
     const err = e as Error & { name?: string };
     if (err.name !== 'TokenExpiredError') id = null;

--- a/common/compiled/node/auth/jwt.ts
+++ b/common/compiled/node/auth/jwt.ts
@@ -132,7 +132,9 @@ export const authUser = async (req, res, next) => {
   }
   if (access_token) {
     try {
-      const access_result = jwt.verify(access_token, getSecret('verify'), { algorithm: [JWT_ALG] });
+      const access_result = jwt.verify(access_token, getSecret('verify'), {
+        algorithms: [JWT_ALG],
+      }) as jwt.JwtPayload & { roles?: string[] };
       if (access_result) {
         req.user = access_result;
         // Attach a scoped FGA check helper so route handlers can do ad-hoc checks
@@ -165,12 +167,12 @@ export const authRefresh = async (req, res) => {
   try {
     const refresh_token = req.cookies?.refresh_token || req.header('refresh_token') || req.query?.refresh_token; // check refresh token & user - always stateful
     const access_token = req.cookies?.access_token || req.header('access_token') || req.query?.access_token; // check refresh token & user - always stateful
-    const user = jwt.decode(access_token);
+    const user = jwt.decode(access_token) as jwt.JwtPayload;
     const { sub, iat } = user;
     if (Math.floor(Date.now() / 1000) > iat + JWT_REFRESH_EXPIRY_SEC) {
       return res.status(401).json({ message: 'Refresh Token Expired' });
     }
-    const refreshToken = await getRefreshToken(sub);
+    const refreshToken = await getRefreshToken(sub as string);
     if (String(refreshToken) === String(refresh_token)) {
       const user = await findUser({ [AUTH_USER_FIELD_LOGIN]: sub });
       // TODO user also include tenant and other information

--- a/common/compiled/node/services/db/redis.ts
+++ b/common/compiled/node/services/db/redis.ts
@@ -1,7 +1,7 @@
-import { Redis } from 'ioredis';
+import { Redis, type RedisOptions } from 'ioredis';
 
 interface RedisConfig {
-  opts: Record<string, unknown>;
+  opts: RedisOptions;
   retry?: { step: number; max: number };
   reconnect?: { targetError: string };
 }
@@ -27,7 +27,7 @@ export default class StoreRedis {
       const { targetError } = this._REDIS_CONFIG.reconnect;
       redisOpts.reconnectOnError = (err: Error) => err.message.includes(targetError);
     }
-    this._redis = new Redis(redisOpts as ConstructorParameters<typeof Redis>[0]);
+    this._redis = new Redis(redisOpts);
   }
 
   /** Returns the underlying ioredis instance, or null if not yet connected. */


### PR DESCRIPTION
## Pull Request Checklist

- [x] I read and followed the [Contribution guide](https://github.com/es-labs/express-template/blob/main/.github/CONTRIBUTING.md)
- [ ] I linked the related issue, if one exists
- [x] I ran the relevant checks or tests for the affected area

## Summary

Three related changes in this PR:

1. **Add type checking for `apps/sample-api`** — adds `tsconfig.json` with `noEmit: true` and a `typecheck` script (`tsc --noEmit`). Fixes all type errors in `sample-api` source and tests, including a production bug where `jwt.verify` was called with `algorithm` (non-existent option) instead of `algorithms`.

2. **Fix `jwt.verify` algorithms option** — `algorithm` is not a valid field in `VerifyOptions`; the correct field is `algorithms`. Without this fix, the algorithm restriction is silently ignored at runtime.

3. **Fix integration test isolation** — `test:integration` was failing when all files ran together due to two issues: shared module cache caused `saml.ts` to be loaded before the SAML test could override `__config`, and parallel execution caused a port 3001 conflict between OIDC and SAML test servers. Fixed with `--test-isolation=process --test-concurrency=1`.

## Affected Area

- [x] apps
- [x] common
- [ ] docs
- [ ] scripts
- [ ] CI/CD or GitHub Actions

## Validation

```text
# Type checking
npm run typecheck --workspace=apps/sample-api
# → zero errors

# Bug fix + unit tests
npm run test:unit --workspace=apps/sample-api
# → all pass

# Integration tests (requires Docker services)
docker compose -f docker/dex/docker-compose.yml up -d
docker compose -f docker/saml/docker-compose.yml up -d
npm run test:integration --workspace=apps/sample-api
# pass 7 / fail 0

# Linting
npm run check
# → zero errors
